### PR TITLE
Fix: Move polling to browser to avoid 50 subrequest limit

### DIFF
--- a/src/app/api/chat/stream/poll/route.ts
+++ b/src/app/api/chat/stream/poll/route.ts
@@ -1,0 +1,59 @@
+import { auth } from "@/auth";
+import { NextRequest } from "next/server";
+
+const ENGINE_BASE_URL = process.env.ENGINE_BASE_URL!;
+const ENGINE_API_KEY = process.env.ENGINE_API_KEY!;
+const DEFAULT_ORG = process.env.DEFAULT_ORG || "unfoldingWord";
+
+export async function GET(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const message_id = searchParams.get("message_id");
+  const cursor = searchParams.get("cursor") ?? "0";
+
+  if (!message_id) {
+    return new Response(JSON.stringify({ error: "Missing message_id" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  try {
+    const pollUrl = `${ENGINE_BASE_URL}/api/v1/chat/queue/poll?user_id=${encodeURIComponent(session.user.id)}&message_id=${encodeURIComponent(message_id)}&org=${encodeURIComponent(DEFAULT_ORG)}&cursor=${encodeURIComponent(cursor)}`;
+
+    const pollResponse = await fetch(pollUrl, {
+      headers: { Authorization: `Bearer ${ENGINE_API_KEY}` },
+    });
+
+    if (!pollResponse.ok) {
+      const errorText = await pollResponse.text();
+      return new Response(
+        JSON.stringify({
+          error: `Poll error: ${pollResponse.status} - ${errorText}`,
+        }),
+        {
+          status: pollResponse.status,
+          headers: { "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    const data = await pollResponse.json();
+    return new Response(JSON.stringify(data), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch {
+    return new Response(
+      JSON.stringify({ error: "Failed to poll for events" }),
+      { status: 502, headers: { "Content-Type": "application/json" } }
+    );
+  }
+}

--- a/src/app/api/chat/stream/poll/route.ts
+++ b/src/app/api/chat/stream/poll/route.ts
@@ -16,10 +16,18 @@ export async function GET(req: NextRequest) {
 
   const { searchParams } = new URL(req.url);
   const message_id = searchParams.get("message_id");
-  const cursor = searchParams.get("cursor") ?? "0";
+  const cursorParam = searchParams.get("cursor") ?? "0";
+  const cursor = Number(cursorParam);
 
   if (!message_id) {
     return new Response(JSON.stringify({ error: "Missing message_id" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (!Number.isFinite(cursor) || cursor < 0) {
+    return new Response(JSON.stringify({ error: "Invalid cursor" }), {
       status: 400,
       headers: { "Content-Type": "application/json" },
     });
@@ -34,9 +42,13 @@ export async function GET(req: NextRequest) {
 
     if (!pollResponse.ok) {
       const errorText = await pollResponse.text();
+      console.error("[poll] upstream error", {
+        status: pollResponse.status,
+        body: errorText,
+      });
       return new Response(
         JSON.stringify({
-          error: `Poll error: ${pollResponse.status} - ${errorText}`,
+          error: `Poll error: ${pollResponse.status}`,
         }),
         {
           status: pollResponse.status,
@@ -48,7 +60,10 @@ export async function GET(req: NextRequest) {
     const data = await pollResponse.json();
     return new Response(JSON.stringify(data), {
       status: 200,
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-store",
+      },
     });
   } catch {
     return new Response(

--- a/src/app/api/chat/stream/route.ts
+++ b/src/app/api/chat/stream/route.ts
@@ -2,17 +2,10 @@ import { auth } from "@/auth";
 import { NextRequest } from "next/server";
 import { z } from "zod";
 
-// Allow up to 2 minutes for AI processing
-export const maxDuration = 120;
-
 const ENGINE_BASE_URL = process.env.ENGINE_BASE_URL!;
 const ENGINE_API_KEY = process.env.ENGINE_API_KEY!;
 const CLIENT_ID = process.env.CLIENT_ID || "web";
 const DEFAULT_ORG = process.env.DEFAULT_ORG || "unfoldingWord";
-
-const POLL_INTERVAL_ACTIVE_MS = 300;
-const POLL_INTERVAL_IDLE_MS = 1000;
-const POLL_MAX_TIME_MS = 120_000;
 
 const ChatStreamRequestSchema = z.object({
   message: z.string(),
@@ -20,13 +13,6 @@ const ChatStreamRequestSchema = z.object({
   audio_base64: z.string().optional(),
   audio_format: z.string().optional(),
 });
-
-interface PollResponse {
-  message_id: string;
-  events: { event: string; data: string }[];
-  done: boolean;
-  cursor: number;
-}
 
 export async function POST(req: NextRequest) {
   // Verify authentication
@@ -50,8 +36,7 @@ export async function POST(req: NextRequest) {
     });
   }
 
-  // Step 1: Enqueue message
-  let message_id: string;
+  // Enqueue message
   try {
     const enqueueResponse = await fetch(
       `${ENGINE_BASE_URL}/api/v1/chat/queue`,
@@ -87,7 +72,7 @@ export async function POST(req: NextRequest) {
     }
 
     const result = await enqueueResponse.json();
-    message_id = result.message_id;
+    const message_id = result.message_id;
 
     if (!message_id) {
       return new Response(
@@ -95,103 +80,15 @@ export async function POST(req: NextRequest) {
         { status: 502, headers: { "Content-Type": "application/json" } }
       );
     }
+
+    return new Response(JSON.stringify({ message_id }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
   } catch {
     return new Response(
       JSON.stringify({ error: "Failed to enqueue message" }),
       { status: 502, headers: { "Content-Type": "application/json" } }
     );
   }
-
-  // Step 2: Poll for events and stream to browser
-  const userId = session.user.id;
-  const encoder = new TextEncoder();
-
-  const stream = new ReadableStream({
-    async start(controller) {
-      controller.enqueue(
-        encoder.encode(
-          `data: ${JSON.stringify({ type: "status", message: "Message queued..." })}\n\n`
-        )
-      );
-
-      let cursor = 0;
-      let pollInterval = POLL_INTERVAL_ACTIVE_MS;
-      const startTime = Date.now();
-
-      try {
-        while (Date.now() - startTime < POLL_MAX_TIME_MS) {
-          const pollUrl = `${ENGINE_BASE_URL}/api/v1/chat/queue/poll?user_id=${encodeURIComponent(userId)}&message_id=${encodeURIComponent(message_id)}&org=${encodeURIComponent(DEFAULT_ORG)}&cursor=${cursor}`;
-
-          const pollResponse = await fetch(pollUrl, {
-            headers: { Authorization: `Bearer ${ENGINE_API_KEY}` },
-          });
-
-          if (!pollResponse.ok) {
-            controller.enqueue(
-              encoder.encode(
-                `data: ${JSON.stringify({ type: "error", error: `Poll error: ${pollResponse.status}` })}\n\n`
-              )
-            );
-            controller.close();
-            return;
-          }
-
-          const pollData: PollResponse = await pollResponse.json();
-
-          for (const event of pollData.events) {
-            if (event.event === "done") continue;
-            controller.enqueue(encoder.encode(`data: ${event.data}\n\n`));
-          }
-
-          cursor = pollData.cursor;
-
-          if (pollData.done) {
-            controller.close();
-            return;
-          }
-
-          // Adaptive polling: fast when events flow, slow when idle
-          pollInterval =
-            pollData.events.length > 0
-              ? POLL_INTERVAL_ACTIVE_MS
-              : Math.min(pollInterval + 200, POLL_INTERVAL_IDLE_MS);
-
-          await new Promise((resolve) => setTimeout(resolve, pollInterval));
-        }
-
-        // Timeout
-        controller.enqueue(
-          encoder.encode(
-            `data: ${JSON.stringify({ type: "error", error: "Request timed out" })}\n\n`
-          )
-        );
-        controller.close();
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        console.error("[stream] polling error", {
-          error: msg,
-          cursor,
-          elapsed: Date.now() - startTime,
-        });
-        try {
-          controller.enqueue(
-            encoder.encode(
-              `data: ${JSON.stringify({ type: "error", error: `Polling error: ${msg}` })}\n\n`
-            )
-          );
-          controller.close();
-        } catch {
-          // Controller already closed (browser disconnected)
-        }
-      }
-    },
-  });
-
-  return new Response(stream, {
-    headers: {
-      "Content-Type": "text/event-stream",
-      "Cache-Control": "no-cache",
-      Connection: "keep-alive",
-    },
-  });
 }

--- a/src/app/api/chat/stream/route.ts
+++ b/src/app/api/chat/stream/route.ts
@@ -60,9 +60,13 @@ export async function POST(req: NextRequest) {
 
     if (!enqueueResponse.ok) {
       const errorText = await enqueueResponse.text();
+      console.error("[enqueue] upstream error", {
+        status: enqueueResponse.status,
+        body: errorText,
+      });
       return new Response(
         JSON.stringify({
-          error: `Enqueue error: ${enqueueResponse.status} - ${errorText}`,
+          error: `Enqueue error: ${enqueueResponse.status}`,
         }),
         {
           status: enqueueResponse.status,

--- a/src/hooks/use-chat-runtime.ts
+++ b/src/hooks/use-chat-runtime.ts
@@ -73,9 +73,17 @@ export function useChatRuntime() {
   const pendingCompleteRef = useRef<{ message: ChatMessage } | null>(null);
   const [isCompleting, setIsCompleting] = useState(false);
   const streamingTextRef = useRef(streamingText);
+  const abortControllerRef = useRef<AbortController | null>(null);
   useEffect(() => {
     streamingTextRef.current = streamingText;
   }, [streamingText]);
+
+  // Abort polling on unmount
+  useEffect(() => {
+    return () => {
+      abortControllerRef.current?.abort();
+    };
+  }, []);
 
   // Load chat history and convert to ChatMessage format
   const loadHistory = useCallback(async (): Promise<ChatMessage[]> => {
@@ -206,6 +214,9 @@ export function useChatRuntime() {
       const POLL_INTERVAL_IDLE_MS = 1500;
       const POLL_MAX_TIME_MS = 120_000;
 
+      const abortController = new AbortController();
+      abortControllerRef.current = abortController;
+
       try {
         // Step 1: Enqueue message
         const enqueueResponse = await fetch("/api/chat/stream", {
@@ -217,6 +228,7 @@ export function useChatRuntime() {
             audio_base64: audioBase64,
             audio_format: audioFormat,
           }),
+          signal: abortController.signal,
         });
 
         if (!enqueueResponse.ok) {
@@ -232,12 +244,14 @@ export function useChatRuntime() {
         let cursor = 0;
         let pollInterval = POLL_INTERVAL_ACTIVE_MS;
         const startTime = Date.now();
+        let handledTerminal = false;
 
         setStatusMessage("Message queued...");
 
         while (Date.now() - startTime < POLL_MAX_TIME_MS) {
           const pollResponse = await fetch(
-            `/api/chat/stream/poll?message_id=${encodeURIComponent(message_id)}&cursor=${cursor}`
+            `/api/chat/stream/poll?message_id=${encodeURIComponent(message_id)}&cursor=${cursor}`,
+            { signal: abortController.signal }
           );
 
           if (!pollResponse.ok) {
@@ -262,8 +276,10 @@ export function useChatRuntime() {
                 setStreamingText((prev) => prev + parsed.text);
               } else if (parsed.type === "complete") {
                 handleComplete(parsed.response);
+                handledTerminal = true;
               } else if (parsed.type === "error") {
                 handleError(parsed.error);
+                handledTerminal = true;
               }
             } catch {
               // Ignore parse errors for individual events
@@ -273,6 +289,10 @@ export function useChatRuntime() {
           cursor = pollData.cursor;
 
           if (pollData.done) {
+            if (!handledTerminal) {
+              setIsLoading(false);
+              setStatusMessage(null);
+            }
             return;
           }
 
@@ -288,8 +308,11 @@ export function useChatRuntime() {
         // Timeout
         handleError("Request timed out after 2 minutes.");
       } catch (error) {
+        if ((error as Error).name === "AbortError") return;
         console.error("Chat error:", error);
         handleError("Sorry, I encountered an error. Please try again.");
+      } finally {
+        abortControllerRef.current = null;
       }
     },
     [handleComplete, handleError]

--- a/src/hooks/use-chat-runtime.ts
+++ b/src/hooks/use-chat-runtime.ts
@@ -202,8 +202,13 @@ export function useChatRuntime() {
       setStatusMessage(null);
       setStreamingText("");
 
+      const POLL_INTERVAL_ACTIVE_MS = 600;
+      const POLL_INTERVAL_IDLE_MS = 1500;
+      const POLL_MAX_TIME_MS = 120_000;
+
       try {
-        const response = await fetch("/api/chat/stream", {
+        // Step 1: Enqueue message
+        const enqueueResponse = await fetch("/api/chat/stream", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -214,51 +219,74 @@ export function useChatRuntime() {
           }),
         });
 
-        if (!response.ok) {
+        if (!enqueueResponse.ok) {
           throw new Error("Failed to send message");
         }
 
-        // Read SSE stream
-        const reader = response.body?.getReader();
-        if (!reader) {
-          throw new Error("No response body");
+        const { message_id } = await enqueueResponse.json();
+        if (!message_id) {
+          throw new Error("No message_id returned");
         }
 
-        const decoder = new TextDecoder();
-        let buffer = "";
+        // Step 2: Poll for events from the browser
+        let cursor = 0;
+        let pollInterval = POLL_INTERVAL_ACTIVE_MS;
+        const startTime = Date.now();
 
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
+        setStatusMessage("Message queued...");
 
-          buffer += decoder.decode(value, { stream: true });
+        while (Date.now() - startTime < POLL_MAX_TIME_MS) {
+          const pollResponse = await fetch(
+            `/api/chat/stream/poll?message_id=${encodeURIComponent(message_id)}&cursor=${cursor}`
+          );
 
-          // Parse SSE events from buffer
-          const lines = buffer.split("\n");
-          buffer = lines.pop() || ""; // Keep incomplete line in buffer
+          if (!pollResponse.ok) {
+            throw new Error(`Poll error: ${pollResponse.status}`);
+          }
 
-          for (const line of lines) {
-            if (line.startsWith("data: ")) {
-              try {
-                const event: SSEEvent = JSON.parse(line.slice(6));
+          const pollData: {
+            message_id: string;
+            events: { event: string; data: string }[];
+            done: boolean;
+            cursor: number;
+          } = await pollResponse.json();
 
-                if (event.type === "status") {
-                  setStatusMessage(event.message);
-                } else if (event.type === "progress") {
-                  // Accumulate streaming text
-                  setStreamingText((prev) => prev + event.text);
-                } else if (event.type === "complete") {
-                  handleComplete(event.response);
-                } else if (event.type === "error") {
-                  handleError(event.error);
-                }
-                // Ignore tool_use and tool_result events for now
-              } catch {
-                // Ignore parse errors
+          for (const event of pollData.events) {
+            if (event.event === "done") continue;
+            try {
+              const parsed: SSEEvent = JSON.parse(event.data);
+
+              if (parsed.type === "status") {
+                setStatusMessage(parsed.message);
+              } else if (parsed.type === "progress") {
+                setStreamingText((prev) => prev + parsed.text);
+              } else if (parsed.type === "complete") {
+                handleComplete(parsed.response);
+              } else if (parsed.type === "error") {
+                handleError(parsed.error);
               }
+            } catch {
+              // Ignore parse errors for individual events
             }
           }
+
+          cursor = pollData.cursor;
+
+          if (pollData.done) {
+            return;
+          }
+
+          // Adaptive polling: fast when events flowing, ramp up when idle
+          pollInterval =
+            pollData.events.length > 0
+              ? POLL_INTERVAL_ACTIVE_MS
+              : Math.min(pollInterval + 200, POLL_INTERVAL_IDLE_MS);
+
+          await new Promise((resolve) => setTimeout(resolve, pollInterval));
         }
+
+        // Timeout
+        handleError("Request timed out after 2 minutes.");
       } catch (error) {
         console.error("Chat error:", error);
         handleError("Sorry, I encountered an error. Please try again.");

--- a/src/hooks/use-chat-runtime.ts
+++ b/src/hooks/use-chat-runtime.ts
@@ -308,7 +308,11 @@ export function useChatRuntime() {
         // Timeout
         handleError("Request timed out after 2 minutes.");
       } catch (error) {
-        if ((error as Error).name === "AbortError") return;
+        if ((error as Error).name === "AbortError") {
+          setIsLoading(false);
+          setStatusMessage(null);
+          return;
+        }
         console.error("Chat error:", error);
         handleError("Sorry, I encountered an error. Please try again.");
       } finally {


### PR DESCRIPTION
## Summary
- Simplified `POST /api/chat/stream` to enqueue-only — returns `{ message_id }` instead of an SSE stream
- Added `GET /api/chat/stream/poll` as a thin authenticated proxy — 1 subrequest per Worker invocation
- Moved the polling loop to `use-chat-runtime.ts` in the browser with adaptive intervals (600ms active / 1500ms idle)

Each browser poll is a separate Worker invocation with its own subrequest budget, so long AI responses no longer hit Cloudflare's 50 subrequest limit at ~15s.

Fixes #7

## Test plan
- [ ] Build succeeds (`npm run build`) — verified locally
- [ ] TypeScript passes (`npx tsc --noEmit`) — verified locally
- [ ] Send a chat message — verify streaming text and completion work
- [ ] Long responses (>15s) complete without "Too many subrequests" error
- [ ] Audio messages still work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)