### PR TITLE
Enable audio message support

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,10 +1,14 @@
 import type { NextConfig } from "next";
 import { initOpenNextCloudflareForDev } from "@opennextjs/cloudflare";
+import packageJson from "./package.json";
 
 initOpenNextCloudflareForDev();
 
 const nextConfig: NextConfig = {
   devIndicators: false,
+  env: {
+    NEXT_PUBLIC_APP_VERSION: packageJson.version,
+  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bt-servant-web-client",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -3,6 +3,7 @@
 import { signIn } from "next-auth/react";
 import { useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { APP_VERSION } from "@/lib/version";
 import { faBookBible } from "@fortawesome/pro-duotone-svg-icons";
 
 export default function LoginPage() {
@@ -135,7 +136,7 @@ export default function LoginPage() {
 
             {/* Footer */}
             <p className="mt-3 text-center font-sans text-[10px] text-[#8a8985] dark:text-[#6b6a68]">
-              BT Servant Web v1.4.0
+              {APP_VERSION}
             </p>
           </div>
         </div>

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -135,7 +135,7 @@ export default function LoginPage() {
 
             {/* Footer */}
             <p className="mt-3 text-center font-sans text-[10px] text-[#8a8985] dark:text-[#6b6a68]">
-              BT Servant Web v1.3.2
+              BT Servant Web v1.4.0
             </p>
           </div>
         </div>

--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -5,6 +5,7 @@ import { useChatContext } from "@/components/providers/assistant-provider";
 import { VoiceRecorder } from "@/components/voice/voice-recorder";
 import { AudioPlayer } from "@/components/voice/audio-player";
 import { useVoiceRecorder } from "@/hooks/use-voice-recorder";
+import { APP_VERSION } from "@/lib/version";
 import { Button } from "@/components/ui/button";
 import {
   ActionBarPrimitive,
@@ -200,7 +201,7 @@ export const Thread: FC = () => {
           />
           <Composer />
           <p className="mt-2 text-center font-sans text-xs text-[#9a9893]">
-            BT Servant Web v1.4.0
+            {APP_VERSION}
           </p>
         </div>
       </AssistantIf>
@@ -283,7 +284,7 @@ const ThreadWelcome: FC = () => {
       {/* Footer */}
       <div className="shrink-0 pb-4">
         <p className="text-center font-sans text-xs text-[#9a9893]">
-          BT Servant Web v1.4.0
+          {APP_VERSION}
         </p>
       </div>
     </div>

--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -5,7 +5,6 @@ import { useChatContext } from "@/components/providers/assistant-provider";
 import { VoiceRecorder } from "@/components/voice/voice-recorder";
 import { AudioPlayer } from "@/components/voice/audio-player";
 import { useVoiceRecorder } from "@/hooks/use-voice-recorder";
-import { AUDIO_ENABLED } from "@/lib/feature-flags";
 import { Button } from "@/components/ui/button";
 import {
   ActionBarPrimitive,
@@ -201,7 +200,7 @@ export const Thread: FC = () => {
           />
           <Composer />
           <p className="mt-2 text-center font-sans text-xs text-[#9a9893]">
-            BT Servant Web v1.3.2
+            BT Servant Web v1.4.0
           </p>
         </div>
       </AssistantIf>
@@ -284,7 +283,7 @@ const ThreadWelcome: FC = () => {
       {/* Footer */}
       <div className="shrink-0 pb-4">
         <p className="text-center font-sans text-xs text-[#9a9893]">
-          BT Servant Web v1.3.2
+          BT Servant Web v1.4.0
         </p>
       </div>
     </div>
@@ -301,7 +300,7 @@ const Composer: FC = () => {
     await sendMessage("", audioBase64, format);
   };
 
-  if (AUDIO_ENABLED && showVoiceRecorder) {
+  if (showVoiceRecorder) {
     return (
       <div className="mx-auto w-full max-w-3xl">
         <VoiceRecorder
@@ -325,8 +324,8 @@ const Composer: FC = () => {
             </div>
           </div>
           <div className="flex shrink-0 items-center gap-2">
-            {/* Voice button - hidden when audio disabled */}
-            {AUDIO_ENABLED && voiceRecorder.isSupported && (
+            {/* Voice button */}
+            {voiceRecorder.isSupported && (
               <button
                 type="button"
                 onClick={() => setShowVoiceRecorder(true)}
@@ -521,8 +520,8 @@ const AssistantMessage: FC = () => {
         )}
       </div>
 
-      {/* Audio player for voice responses - hidden when audio disabled */}
-      {AUDIO_ENABLED && audioBase64 && (
+      {/* Audio player for voice responses */}
+      {audioBase64 && (
         <div className="mt-2">
           <AudioPlayer audioBase64={audioBase64} />
         </div>

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -1,1 +1,0 @@
-export const AUDIO_ENABLED = process.env.NEXT_PUBLIC_AUDIO_ENABLED === "true";

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,3 +1,1 @@
-import packageJson from "../../package.json";
-
-export const APP_VERSION = `BT Servant Web v${packageJson.version}`;
+export const APP_VERSION = `BT Servant Web v${process.env.NEXT_PUBLIC_APP_VERSION}`;

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,0 +1,3 @@
+import packageJson from "../../package.json";
+
+export const APP_VERSION = `BT Servant Web v${packageJson.version}`;


### PR DESCRIPTION
## Summary
- Remove the `AUDIO_ENABLED` feature flag so voice recording and audio playback are always available — the backend now fully supports audio messages (STT via Whisper, TTS via Deepgram Aura 2)
- Delete `src/lib/feature-flags.ts` and remove all conditional checks gated behind it
- Bump version to v1.4.0

## Test plan
- [ ] `npm run dev` — confirm mic button appears in the composer
- [ ] Click mic — confirm VoiceRecorder UI appears
- [ ] Record and send — confirm request hits `/api/chat/stream` with `message_type: "audio"`
- [ ] Confirm audio player appears on response (if backend returns `voice_audio_base64`)
- [ ] CI passes (lint, typecheck, build)

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)