### PR TITLE
Add error logging for audio send failures

### DIFF
--- a/src/app/api/chat/stream/route.ts
+++ b/src/app/api/chat/stream/route.ts
@@ -29,11 +29,18 @@ export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
     parsed = ChatStreamRequestSchema.parse(body);
-  } catch {
-    return new Response(JSON.stringify({ error: "Invalid request" }), {
-      status: 400,
-      headers: { "Content-Type": "application/json" },
-    });
+  } catch (error) {
+    console.error("[chat/stream] parse error", error);
+    return new Response(
+      JSON.stringify({
+        error: "Invalid request",
+        details: error instanceof Error ? error.message : String(error),
+      }),
+      {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      }
+    );
   }
 
   // Enqueue message

--- a/src/hooks/use-chat-runtime.ts
+++ b/src/hooks/use-chat-runtime.ts
@@ -234,7 +234,12 @@ export function useChatRuntime() {
         });
 
         if (!enqueueResponse.ok) {
-          throw new Error("Failed to send message");
+          const errorBody = await enqueueResponse.text();
+          console.error("[sendMessage] enqueue failed", {
+            status: enqueueResponse.status,
+            body: errorBody,
+          });
+          throw new Error(`Failed to send message (${enqueueResponse.status})`);
         }
 
         const { message_id } = await enqueueResponse.json();
@@ -322,6 +327,7 @@ export function useChatRuntime() {
           setStatusMessage(null);
           return;
         }
+        console.error("[sendMessage] error", error);
         handleError("Sorry, I encountered an error. Please try again.");
       } finally {
         abortControllerRef.current = null;


### PR DESCRIPTION
## Summary

- Add detailed error logging on both client and server for message send failures
- Server now returns error `details` in the 400 response body
- Client logs enqueue failures with status code and response body

Needed to diagnose 400 errors when sending voice messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)