### PR TITLE
Forward engine error details to client

### DIFF
--- a/src/app/api/chat/stream/route.ts
+++ b/src/app/api/chat/stream/route.ts
@@ -74,6 +74,7 @@ export async function POST(req: NextRequest) {
       return new Response(
         JSON.stringify({
           error: `Enqueue error: ${enqueueResponse.status}`,
+          details: errorText,
         }),
         {
           status: enqueueResponse.status,


### PR DESCRIPTION
## Summary

- Forward the upstream engine error body in the 400 response so the browser console shows exactly why the engine rejected the audio payload

One-line change to unblock debugging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)