### PR TITLE
feat: R2 audio URLs with refresh persistence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,11 @@
 # CLAUDE.md
 
+## Cross-Repo Rules
+
+- **NEVER modify files in other repositories** (e.g., `../bt-servant-worker`)
+  without explicit permission from the user. Reading/researching other repos is
+  fine — writing requires approval.
+
 ## Sensitive Areas
 
 Before modifying code in these areas, read the linked documentation first:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bt-servant-web-client",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/api/audio/route.ts
+++ b/src/app/api/audio/route.ts
@@ -1,0 +1,68 @@
+import { auth } from "@/auth";
+import { NextRequest } from "next/server";
+
+const ENGINE_BASE_URL = process.env.ENGINE_BASE_URL!;
+const ENGINE_API_KEY = process.env.ENGINE_API_KEY!;
+
+export async function GET(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const audioUrl = searchParams.get("url");
+
+  if (!audioUrl) {
+    return new Response(JSON.stringify({ error: "Missing url parameter" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  // SSRF prevention: only allow URLs pointing to our engine
+  if (!audioUrl.startsWith(ENGINE_BASE_URL)) {
+    return new Response(JSON.stringify({ error: "Invalid audio URL" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  try {
+    const audioResponse = await fetch(audioUrl, {
+      headers: { Authorization: `Bearer ${ENGINE_API_KEY}` },
+    });
+
+    if (!audioResponse.ok) {
+      return new Response(
+        JSON.stringify({ error: `Audio fetch error: ${audioResponse.status}` }),
+        {
+          status: audioResponse.status,
+          headers: { "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    // Stream the audio response back with upstream headers
+    const contentType =
+      audioResponse.headers.get("Content-Type") || "audio/mpeg";
+    const cacheControl =
+      audioResponse.headers.get("Cache-Control") || "public, max-age=86400";
+
+    return new Response(audioResponse.body, {
+      status: 200,
+      headers: {
+        "Content-Type": contentType,
+        "Cache-Control": cacheControl,
+      },
+    });
+  } catch {
+    return new Response(JSON.stringify({ error: "Failed to fetch audio" }), {
+      status: 502,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+}

--- a/src/app/api/audio/route.ts
+++ b/src/app/api/audio/route.ts
@@ -23,8 +23,19 @@ export async function GET(req: NextRequest) {
     });
   }
 
-  // SSRF prevention: only allow URLs pointing to our engine
-  if (!audioUrl.startsWith(ENGINE_BASE_URL)) {
+  // SSRF prevention: only allow URLs pointing to our engine (origin comparison
+  // prevents bypass via e.g. https://engine.example.com.evil.com/path)
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(audioUrl);
+  } catch {
+    return new Response(JSON.stringify({ error: "Invalid audio URL" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (parsedUrl.origin !== new URL(ENGINE_BASE_URL).origin) {
     return new Response(JSON.stringify({ error: "Invalid audio URL" }), {
       status: 400,
       headers: { "Content-Type": "application/json" },
@@ -52,11 +63,15 @@ export async function GET(req: NextRequest) {
     const cacheControl =
       audioResponse.headers.get("Cache-Control") || "public, max-age=86400";
 
+    // Extract filename from URL path for Content-Disposition
+    const filename = parsedUrl.pathname.split("/").pop() || "audio.mp3";
+
     return new Response(audioResponse.body, {
       status: 200,
       headers: {
         "Content-Type": contentType,
         "Cache-Control": cacheControl,
+        "Content-Disposition": `inline; filename="${filename}"`,
       },
     });
   } catch {

--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -136,10 +136,13 @@ const ScrollToBottomButton: FC<{ visible: boolean; onClick: () => void }> = ({
 };
 
 const LoadingIndicator: FC = () => {
-  const { isLoading, statusMessage, streamingText } = useChatContext();
+  const { isLoading, statusMessage, streamingText, isAudioRequest } =
+    useChatContext();
 
-  // Only show loading indicator when loading and no streaming text yet
-  if (!isLoading || streamingText) return null;
+  // Show loading indicator when loading and either:
+  // - no streaming text yet (text requests), or
+  // - audio request (streaming text is hidden, so keep showing status)
+  if (!isLoading || (streamingText && !isAudioRequest)) return null;
 
   return (
     <div className="mx-auto w-full max-w-3xl px-2">
@@ -492,9 +495,12 @@ const AnimatedText: FC<{
 };
 
 const AssistantMessage: FC = () => {
-  const { finalizeComplete, isCompleting } = useChatContext();
+  const { finalizeComplete, isCompleting, isLoading } = useChatContext();
   const audioBase64 = useAssistantState(
     ({ message }) => message.metadata?.custom?.audioBase64 as string | undefined
+  );
+  const audioUrl = useAssistantState(
+    ({ message }) => message.metadata?.custom?.audioUrl as string | undefined
   );
   const isStreaming = useAssistantState(
     ({ message }) =>
@@ -510,38 +516,33 @@ const AssistantMessage: FC = () => {
     finalizeComplete();
   }, [finalizeComplete]);
 
-  const hasAudio = !isStreaming && !!audioBase64;
-  const hasText = !!messageText;
+  const [showTranscript, setShowTranscript] = useState(false);
 
-  useEffect(() => {
-    console.log("[AssistantMessage] render state", {
-      hasAudio,
-      hasText,
-      isStreaming,
-      isCompleting,
-      audioLen: audioBase64?.length ?? 0,
-      textLen: messageText.length,
-      isLast,
-    });
-  }, [
-    hasAudio,
-    hasText,
-    isStreaming,
-    isCompleting,
-    audioBase64,
-    messageText,
-    isLast,
-  ]);
+  const hasAudio = !isStreaming && (!!audioBase64 || !!audioUrl);
+  const hasText = !!messageText;
 
   return (
     <div className="relative mb-8 pl-2">
       {hasAudio ? (
-        // Audio-only: show AudioPlayer, hide text and action bar
         <div className="mt-2">
-          <AudioPlayer audioBase64={audioBase64} />
+          <AudioPlayer audioBase64={audioBase64} audioUrl={audioUrl} />
+          {hasText && (
+            <div className="mt-2">
+              <button
+                onClick={() => setShowTranscript((prev) => !prev)}
+                className="font-sans text-[0.75rem] text-[#8a8985] transition-colors hover:text-[#6b6a68] dark:text-[#9a9893] dark:hover:text-[#b8b5a9]"
+              >
+                {showTranscript ? "Hide transcript" : "Show transcript"}
+              </button>
+              {showTranscript && (
+                <div className="prose prose-neutral dark:prose-invert mt-2 max-w-none font-serif leading-[1.65rem] text-[#1a1a18] dark:text-[#eee]">
+                  <MessagePrimitive.Parts components={{ Text: MarkdownText }} />
+                </div>
+              )}
+            </div>
+          )}
         </div>
       ) : isStreaming ? (
-        // Streaming: show animated text (audio may arrive on complete)
         <div className="prose prose-neutral dark:prose-invert max-w-none font-serif leading-[1.65rem] text-[#1a1a18] dark:text-[#eee]">
           <AnimatedText
             text={messageText}
@@ -550,7 +551,6 @@ const AssistantMessage: FC = () => {
           />
         </div>
       ) : hasText ? (
-        // Text fallback: render as before with action bar
         <>
           <div className="prose prose-neutral dark:prose-invert max-w-none font-serif leading-[1.65rem] text-[#1a1a18] dark:text-[#eee]">
             <MessagePrimitive.Parts components={{ Text: MarkdownText }} />
@@ -575,8 +575,7 @@ const AssistantMessage: FC = () => {
             </ActionBarPrimitive.Root>
           </div>
         </>
-      ) : isLast ? (
-        // Neither audio nor text on the latest message: show error
+      ) : isLast && !isLoading ? (
         <div className="prose prose-neutral dark:prose-invert max-w-none font-serif leading-[1.65rem] text-[#1a1a18] dark:text-[#eee]">
           <p className="text-[#8a8985] italic dark:text-[#b8b5a9]">
             Sorry, I couldn&apos;t deliver a response. Please try again.

--- a/src/components/providers/assistant-provider.tsx
+++ b/src/components/providers/assistant-provider.tsx
@@ -11,6 +11,7 @@ interface ChatContextValue {
     audioFormat?: string
   ) => Promise<void>;
   isLoading: boolean;
+  isAudioRequest: boolean;
   statusMessage: string | null;
   streamingText: string;
   finalizeComplete: () => void;
@@ -31,6 +32,7 @@ export function AssistantProvider({ children }: { children: ReactNode }) {
     runtime,
     sendMessage,
     isLoading,
+    isAudioRequest,
     statusMessage,
     streamingText,
     finalizeComplete,
@@ -42,6 +44,7 @@ export function AssistantProvider({ children }: { children: ReactNode }) {
       value={{
         sendMessage,
         isLoading,
+        isAudioRequest,
         statusMessage,
         streamingText,
         finalizeComplete,

--- a/src/components/voice/audio-player.tsx
+++ b/src/components/voice/audio-player.tsx
@@ -7,7 +7,8 @@ import { useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
 
 interface AudioPlayerProps {
-  audioBase64: string;
+  audioBase64?: string;
+  audioUrl?: string;
   format?: string;
   autoPlay?: boolean;
   className?: string;
@@ -15,25 +16,35 @@ interface AudioPlayerProps {
 
 export function AudioPlayer({
   audioBase64,
+  audioUrl,
   format = "mp3",
   autoPlay = false,
   className,
 }: AudioPlayerProps) {
-  const { isPlaying, currentTime, duration, play, pause, seek } =
+  const { isPlaying, currentTime, duration, play, playUrl, pause, seek } =
     useAudioPlayer();
   const progressRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (autoPlay) {
+  const startPlayback = () => {
+    if (audioUrl) {
+      playUrl(audioUrl);
+    } else if (audioBase64) {
       play(audioBase64, format);
     }
-  }, [audioBase64, format, autoPlay, play]);
+  };
+
+  useEffect(() => {
+    if (autoPlay) {
+      startPlayback();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [audioBase64, audioUrl, format, autoPlay]);
 
   const handleToggle = () => {
     if (isPlaying) {
       pause();
     } else {
-      play(audioBase64, format);
+      startPlayback();
     }
   };
 

--- a/src/hooks/use-audio-player.ts
+++ b/src/hooks/use-audio-player.ts
@@ -19,6 +19,7 @@ export function useAudioPlayer(): UseAudioPlayerReturn {
   const [duration, setDuration] = useState(0);
 
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  const currentSrcRef = useRef<string | null>(null);
 
   // Clean up on unmount
   useEffect(() => {
@@ -30,55 +31,15 @@ export function useAudioPlayer(): UseAudioPlayerReturn {
     };
   }, []);
 
-  const play = useCallback((base64Audio: string, format: string = "mp3") => {
-    // Stop any existing playback
-    if (audioRef.current) {
-      audioRef.current.pause();
+  const startAudio = useCallback((src: string) => {
+    // Resume if same source is paused
+    if (audioRef.current && currentSrcRef.current === src) {
+      audioRef.current.play().catch((error) => {
+        console.error("Failed to play audio:", error);
+      });
+      return;
     }
 
-    // Create audio element
-    const audio = new Audio();
-    audioRef.current = audio;
-
-    // Set source from base64
-    const mimeType =
-      format === "mp3"
-        ? "audio/mpeg"
-        : format === "ogg"
-          ? "audio/ogg"
-          : format === "webm"
-            ? "audio/webm"
-            : "audio/mpeg";
-    audio.src = `data:${mimeType};base64,${base64Audio}`;
-
-    // Event handlers
-    audio.onloadedmetadata = () => {
-      setDuration(audio.duration);
-    };
-
-    audio.ontimeupdate = () => {
-      setCurrentTime(audio.currentTime);
-    };
-
-    audio.onplay = () => setIsPlaying(true);
-    audio.onpause = () => setIsPlaying(false);
-    audio.onended = () => {
-      setIsPlaying(false);
-      setCurrentTime(0);
-    };
-
-    audio.onerror = (e) => {
-      console.error("Audio playback error:", e);
-      setIsPlaying(false);
-    };
-
-    // Start playback
-    audio.play().catch((error) => {
-      console.error("Failed to play audio:", error);
-    });
-  }, []);
-
-  const playUrl = useCallback((url: string) => {
     // Stop any existing playback
     if (audioRef.current) {
       audioRef.current.pause();
@@ -86,7 +47,8 @@ export function useAudioPlayer(): UseAudioPlayerReturn {
 
     const audio = new Audio();
     audioRef.current = audio;
-    audio.src = url;
+    currentSrcRef.current = src;
+    audio.src = src;
 
     audio.onloadedmetadata = () => {
       setDuration(audio.duration);
@@ -112,6 +74,28 @@ export function useAudioPlayer(): UseAudioPlayerReturn {
       console.error("Failed to play audio:", error);
     });
   }, []);
+
+  const play = useCallback(
+    (base64Audio: string, format: string = "mp3") => {
+      const mimeType =
+        format === "mp3"
+          ? "audio/mpeg"
+          : format === "ogg"
+            ? "audio/ogg"
+            : format === "webm"
+              ? "audio/webm"
+              : "audio/mpeg";
+      startAudio(`data:${mimeType};base64,${base64Audio}`);
+    },
+    [startAudio]
+  );
+
+  const playUrl = useCallback(
+    (url: string) => {
+      startAudio(url);
+    },
+    [startAudio]
+  );
 
   const pause = useCallback(() => {
     audioRef.current?.pause();

--- a/src/hooks/use-audio-player.ts
+++ b/src/hooks/use-audio-player.ts
@@ -7,6 +7,7 @@ interface UseAudioPlayerReturn {
   currentTime: number;
   duration: number;
   play: (base64Audio: string, format?: string) => void;
+  playUrl: (url: string) => void;
   pause: () => void;
   stop: () => void;
   seek: (time: number) => void;
@@ -77,6 +78,41 @@ export function useAudioPlayer(): UseAudioPlayerReturn {
     });
   }, []);
 
+  const playUrl = useCallback((url: string) => {
+    // Stop any existing playback
+    if (audioRef.current) {
+      audioRef.current.pause();
+    }
+
+    const audio = new Audio();
+    audioRef.current = audio;
+    audio.src = url;
+
+    audio.onloadedmetadata = () => {
+      setDuration(audio.duration);
+    };
+
+    audio.ontimeupdate = () => {
+      setCurrentTime(audio.currentTime);
+    };
+
+    audio.onplay = () => setIsPlaying(true);
+    audio.onpause = () => setIsPlaying(false);
+    audio.onended = () => {
+      setIsPlaying(false);
+      setCurrentTime(0);
+    };
+
+    audio.onerror = (e) => {
+      console.error("Audio playback error:", e);
+      setIsPlaying(false);
+    };
+
+    audio.play().catch((error) => {
+      console.error("Failed to play audio:", error);
+    });
+  }, []);
+
   const pause = useCallback(() => {
     audioRef.current?.pause();
   }, []);
@@ -101,6 +137,7 @@ export function useAudioPlayer(): UseAudioPlayerReturn {
     currentTime,
     duration,
     play,
+    playUrl,
     pause,
     stop,
     seek,

--- a/src/hooks/use-chat-runtime.ts
+++ b/src/hooks/use-chat-runtime.ts
@@ -53,18 +53,16 @@ function createMessage(
   id: string,
   role: "user" | "assistant",
   content: string,
-  audioBase64?: string,
-  isStreaming?: boolean,
-  audioUrl?: string
+  opts?: { audioBase64?: string; audioUrl?: string; isStreaming?: boolean }
 ): ChatMessage {
   return {
     id,
     role,
     content: [{ type: "text" as const, text: content }],
     createdAt: new Date(),
-    audioBase64,
-    audioUrl,
-    isStreaming,
+    audioBase64: opts?.audioBase64,
+    audioUrl: opts?.audioUrl,
+    isStreaming: opts?.isStreaming,
   };
 }
 
@@ -151,7 +149,8 @@ export function useChatRuntime() {
       return;
     }
 
-    const hasAudio = !!pending.message.audioBase64;
+    const hasAudio =
+      !!pending.message.audioBase64 || !!pending.message.audioUrl;
     const textLen =
       pending.message.content[0]?.type === "text"
         ? pending.message.content[0].text.length
@@ -195,9 +194,10 @@ export function useChatRuntime() {
       `assistant-${Date.now()}`,
       "assistant",
       joinedResponse,
-      data.voice_audio_base64 || undefined,
-      undefined,
-      audioUrl
+      {
+        audioBase64: data.voice_audio_base64 || undefined,
+        audioUrl,
+      }
     );
 
     // For audio requests or when no streaming text was shown, swap immediately.
@@ -353,7 +353,12 @@ export function useChatRuntime() {
                 console.log("[poll] status:", parsed.message);
                 setStatusMessage(parsed.message);
                 // TTS can take minutes for long responses — extend inactivity window
-                if (parsed.message.toLowerCase().includes("generating audio")) {
+                const statusLower = parsed.message.toLowerCase();
+                if (
+                  statusLower.includes("audio") ||
+                  statusLower.includes("tts") ||
+                  statusLower.includes("speech")
+                ) {
                   inactivityLimit = POLL_INACTIVITY_AUDIO_GEN_MS;
                 }
               } else if (parsed.type === "progress") {
@@ -428,6 +433,8 @@ export function useChatRuntime() {
       } catch (error) {
         if ((error as Error).name === "AbortError") {
           setIsLoading(false);
+          setIsAudioRequest(false);
+          isAudioRequestRef.current = false;
           setStatusMessage(null);
           return;
         }
@@ -449,8 +456,7 @@ export function useChatRuntime() {
         "streaming",
         "assistant",
         streamingText,
-        undefined,
-        true
+        { isStreaming: true }
       );
       return [...messages, streamingMessage];
     }

--- a/src/hooks/use-chat-runtime.ts
+++ b/src/hooks/use-chat-runtime.ts
@@ -17,6 +17,7 @@ interface ChatMessage {
   content: Array<{ type: "text"; text: string }>;
   createdAt: Date;
   audioBase64?: string;
+  audioUrl?: string;
   isStreaming?: boolean;
 }
 
@@ -29,6 +30,7 @@ function toThreadMessage(message: ChatMessage): ThreadMessageLike {
     metadata: {
       custom: {
         audioBase64: message.audioBase64,
+        audioUrl: message.audioUrl,
         isStreaming: message.isStreaming,
       },
     },
@@ -52,7 +54,8 @@ function createMessage(
   role: "user" | "assistant",
   content: string,
   audioBase64?: string,
-  isStreaming?: boolean
+  isStreaming?: boolean,
+  audioUrl?: string
 ): ChatMessage {
   return {
     id,
@@ -60,6 +63,7 @@ function createMessage(
     content: [{ type: "text" as const, text: content }],
     createdAt: new Date(),
     audioBase64,
+    audioUrl,
     isStreaming,
   };
 }
@@ -69,6 +73,8 @@ export function useChatRuntime() {
   const [isLoading, setIsLoading] = useState(false);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [streamingText, setStreamingText] = useState<string>("");
+  const [isAudioRequest, setIsAudioRequest] = useState(false);
+  const isAudioRequestRef = useRef(false);
   const historyLoadedRef = useRef(false);
   const pendingCompleteRef = useRef<{ message: ChatMessage } | null>(null);
   const [isCompleting, setIsCompleting] = useState(false);
@@ -113,6 +119,9 @@ export function useChatRuntime() {
           role: "assistant",
           content: [{ type: "text" as const, text: entry.assistant_response }],
           createdAt: entry.created_at ? new Date(entry.created_at) : new Date(),
+          audioUrl: entry.voice_audio_url
+            ? `/api/audio?url=${encodeURIComponent(entry.voice_audio_url)}`
+            : undefined,
         });
       });
 
@@ -156,6 +165,7 @@ export function useChatRuntime() {
     // React 18+ auto-batches these into a single render
     setIsCompleting(false);
     setIsLoading(false);
+    setIsAudioRequest(false);
     setStatusMessage(null);
     setMessages((prev) => [...prev, pending.message]);
     setStreamingText("");
@@ -165,7 +175,7 @@ export function useChatRuntime() {
   const handleComplete = useCallback((data: ChatResponse) => {
     const joinedResponse = data.responses.join("\n\n");
     const currentStreaming = streamingTextRef.current;
-    const hasAudio = !!data.voice_audio_base64;
+    const hasAudio = !!data.voice_audio_base64 || !!data.voice_audio_url;
 
     console.log("[handleComplete]", {
       hasAudio,
@@ -174,20 +184,35 @@ export function useChatRuntime() {
       joinedLen: joinedResponse.length,
       streamingLen: currentStreaming.length,
       audioLen: data.voice_audio_base64?.length ?? 0,
+      audioUrl: data.voice_audio_url ?? null,
     });
+
+    const audioUrl = data.voice_audio_url
+      ? `/api/audio?url=${encodeURIComponent(data.voice_audio_url)}`
+      : undefined;
 
     const assistantMessage = createMessage(
       `assistant-${Date.now()}`,
       "assistant",
       joinedResponse,
-      data.voice_audio_base64 || undefined
+      data.voice_audio_base64 || undefined,
+      undefined,
+      audioUrl
     );
 
-    // If no streaming text was accumulated, swap immediately
-    if (!currentStreaming) {
-      console.log("[handleComplete] immediate swap (no streaming text)");
+    // For audio requests or when no streaming text was shown, swap immediately.
+    // AnimatedText is not rendered for audio requests so the deferred path
+    // would never call finalizeComplete.
+    if (!currentStreaming || isAudioRequestRef.current) {
+      console.log("[handleComplete] immediate swap", {
+        reason: isAudioRequestRef.current
+          ? "audio request"
+          : "no streaming text",
+      });
       setMessages((prev) => [...prev, assistantMessage]);
       setIsLoading(false);
+      setIsAudioRequest(false);
+      isAudioRequestRef.current = false;
       setStatusMessage(null);
       setStreamingText("");
       return;
@@ -207,6 +232,8 @@ export function useChatRuntime() {
     console.error("[handleError]", errorMessage);
     pendingCompleteRef.current = null;
     setIsCompleting(false);
+    setIsAudioRequest(false);
+    isAudioRequestRef.current = false;
     setMessages((prev) => [
       ...prev,
       createMessage(`error-${Date.now()}`, "assistant", errorMessage),
@@ -235,12 +262,16 @@ export function useChatRuntime() {
 
       setMessages((prev) => [...prev, userMessage]);
       setIsLoading(true);
+      setIsAudioRequest(!!audioBase64);
+      isAudioRequestRef.current = !!audioBase64;
       setStatusMessage(null);
       setStreamingText("");
 
       const POLL_INTERVAL_ACTIVE_MS = 600;
       const POLL_INTERVAL_IDLE_MS = 1500;
-      const POLL_MAX_TIME_MS = 120_000;
+      const POLL_HARD_MAX_MS = 300_000; // 5 min absolute ceiling
+      const POLL_INACTIVITY_DEFAULT_MS = 120_000; // 2 min without any event = dead
+      const POLL_INACTIVITY_AUDIO_GEN_MS = 300_000; // 5 min during TTS (matches hard max)
 
       const abortController = new AbortController();
       abortControllerRef.current = abortController;
@@ -283,11 +314,16 @@ export function useChatRuntime() {
         let cursor = 0;
         let pollInterval = POLL_INTERVAL_ACTIVE_MS;
         const startTime = Date.now();
+        let lastActivityTime = startTime;
+        let inactivityLimit = POLL_INACTIVITY_DEFAULT_MS;
         let handledTerminal = false;
 
         setStatusMessage("Message queued...");
 
-        while (Date.now() - startTime < POLL_MAX_TIME_MS) {
+        while (
+          Date.now() - startTime < POLL_HARD_MAX_MS &&
+          Date.now() - lastActivityTime < inactivityLimit
+        ) {
           const pollResponse = await fetch(
             `/api/chat/stream/poll?message_id=${encodeURIComponent(message_id)}&cursor=${cursor}`,
             { signal: abortController.signal }
@@ -304,6 +340,10 @@ export function useChatRuntime() {
             cursor: number;
           } = await pollResponse.json();
 
+          if (pollData.events.length > 0) {
+            lastActivityTime = Date.now();
+          }
+
           for (const event of pollData.events) {
             if (event.event === "done") continue;
             try {
@@ -312,6 +352,10 @@ export function useChatRuntime() {
               if (parsed.type === "status") {
                 console.log("[poll] status:", parsed.message);
                 setStatusMessage(parsed.message);
+                // TTS can take minutes for long responses — extend inactivity window
+                if (parsed.message.toLowerCase().includes("generating audio")) {
+                  inactivityLimit = POLL_INACTIVITY_AUDIO_GEN_MS;
+                }
               } else if (parsed.type === "progress") {
                 // Guard: ignore progress chunks that arrive after a complete/error
                 // event. Without this, straggling chunks append to streamingText
@@ -372,8 +416,15 @@ export function useChatRuntime() {
           await new Promise((resolve) => setTimeout(resolve, pollInterval));
         }
 
-        // Timeout
-        handleError("Request timed out after 2 minutes.");
+        // Timeout — either hard max (5 min) or inactivity
+        const elapsed = Math.round((Date.now() - startTime) / 1000);
+        const inactive = Math.round((Date.now() - lastActivityTime) / 1000);
+        const reason =
+          Date.now() - lastActivityTime >= inactivityLimit
+            ? `No response activity for ${inactive}s`
+            : `Request exceeded ${Math.round(POLL_HARD_MAX_MS / 1000)}s limit`;
+
+        handleError(`${reason} (elapsed ${elapsed}s).`);
       } catch (error) {
         if ((error as Error).name === "AbortError") {
           setIsLoading(false);
@@ -389,9 +440,11 @@ export function useChatRuntime() {
     [handleComplete, handleError]
   );
 
-  // Combine messages with streaming message if present
+  // Combine messages with streaming message if present.
+  // For audio requests, suppress the visible streaming text — the user
+  // will only see the audio player (with optional transcript toggle).
   const allMessages = useMemo(() => {
-    if (streamingText) {
+    if (streamingText && !isAudioRequest) {
       const streamingMessage = createMessage(
         "streaming",
         "assistant",
@@ -402,7 +455,7 @@ export function useChatRuntime() {
       return [...messages, streamingMessage];
     }
     return messages;
-  }, [messages, streamingText]);
+  }, [messages, streamingText, isAudioRequest]);
 
   // Create assistant-ui runtime
   const runtime = useExternalStoreRuntime({
@@ -420,6 +473,7 @@ export function useChatRuntime() {
     runtime,
     messages: allMessages,
     isLoading,
+    isAudioRequest,
     statusMessage,
     streamingText,
     sendMessage,

--- a/src/types/engine.ts
+++ b/src/types/engine.ts
@@ -16,6 +16,7 @@ export interface ChatResponse {
   responses: string[];
   response_language: string;
   voice_audio_base64: string | null;
+  voice_audio_url?: string;
 }
 
 export interface UserPreferences {
@@ -27,6 +28,7 @@ export interface ChatHistoryEntry {
   assistant_response: string;
   timestamp?: number;
   created_at?: string | null;
+  voice_audio_url?: string | null;
 }
 
 export interface ChatHistoryResponse {


### PR DESCRIPTION
## Summary

- Replace inline base64 audio with R2 URL-based playback via authenticated proxy route (`/api/audio`)
- Load audio URLs from chat history so audio survives page refresh
- Add `playUrl()` to audio player hook for URL-sourced audio
- Remove `audio_chunk` SSE event handling (superseded by R2 storage)
- Extend poll timeouts: 5min hard max, 2min inactivity (5min during TTS)
- Fix LoadingIndicator visibility during audio requests
- Add transcript toggle for audio messages with text

Closes #19

## Test plan

- [ ] Text-only messages: streaming animation works as before
- [ ] Voice message with R2 audio: text appears, then AudioPlayer renders with audio from URL
- [ ] Page refresh: history loads with AudioPlayer on past audio messages
- [ ] Backward compat: inline base64 audio still plays if worker returns it
- [ ] Proxy security: `/api/audio?url=https://evil.com` returns 400
- [ ] Timeout: poll exits cleanly after inactivity

🤖 Generated with [Claude Code](https://claude.com/claude-code)