### PR TITLE
feat: add org switcher with localStorage persistence

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bt-servant-web-client",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/(protected)/chat/page.tsx
+++ b/src/app/(protected)/chat/page.tsx
@@ -5,11 +5,13 @@ import { UserMenu } from "@/components/user-menu";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faBookBible } from "@fortawesome/pro-duotone-svg-icons";
 
+const DEFAULT_ORG = process.env.DEFAULT_ORG || "unfoldingWord";
+
 export default async function ChatPage() {
   const session = await auth();
 
   return (
-    <AssistantProvider>
+    <AssistantProvider defaultOrg={DEFAULT_ORG}>
       <div className="flex h-dvh flex-col overscroll-none bg-gradient-to-b from-[#F5F5F0] from-70% to-[#E5E5DD] dark:from-[#2b2a27] dark:from-70% dark:to-[#201f1d]">
         <header className="flex items-center justify-between bg-transparent px-4 py-3">
           <div className="flex items-center gap-2">

--- a/src/app/api/chat/history/route.ts
+++ b/src/app/api/chat/history/route.ts
@@ -1,5 +1,6 @@
 import { auth } from "@/auth";
 import { getChatHistory } from "@/lib/engine-client";
+import { validateOrg } from "@/lib/validate-org";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function GET(req: NextRequest) {
@@ -12,8 +13,9 @@ export async function GET(req: NextRequest) {
     const { searchParams } = new URL(req.url);
     const limit = parseInt(searchParams.get("limit") || "50", 10);
     const offset = parseInt(searchParams.get("offset") || "0", 10);
+    const org = validateOrg(searchParams.get("org"));
 
-    const history = await getChatHistory(session.user.id, limit, offset);
+    const history = await getChatHistory(session.user.id, limit, offset, org);
 
     return NextResponse.json(history);
   } catch (error) {

--- a/src/app/api/chat/stream/route.ts
+++ b/src/app/api/chat/stream/route.ts
@@ -1,17 +1,18 @@
 import { auth } from "@/auth";
+import { validateOrg } from "@/lib/validate-org";
 import { NextRequest } from "next/server";
 import { z } from "zod";
 
 const ENGINE_BASE_URL = process.env.ENGINE_BASE_URL!;
 const ENGINE_API_KEY = process.env.ENGINE_API_KEY!;
 const CLIENT_ID = process.env.CLIENT_ID || "web";
-const DEFAULT_ORG = process.env.DEFAULT_ORG || "unfoldingWord";
 
 const ChatStreamRequestSchema = z.object({
   message: z.string(),
   message_type: z.enum(["text", "audio"]).default("text"),
   audio_base64: z.string().optional(),
   audio_format: z.string().optional(),
+  org: z.string().optional(),
 });
 
 export async function POST(req: NextRequest) {
@@ -56,7 +57,7 @@ export async function POST(req: NextRequest) {
         },
         body: JSON.stringify({
           user_id: session.user.id,
-          org: DEFAULT_ORG,
+          org: validateOrg(parsed.org),
           message: parsed.message,
           message_type: parsed.message_type,
           client_id: CLIENT_ID,

--- a/src/app/api/preferences/route.ts
+++ b/src/app/api/preferences/route.ts
@@ -1,5 +1,6 @@
 import { auth } from "@/auth";
 import { getUserPreferences, updateUserPreferences } from "@/lib/engine-client";
+import { validateOrg } from "@/lib/validate-org";
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 
@@ -7,14 +8,17 @@ const PreferencesSchema = z.object({
   response_language: z.string().optional(),
 });
 
-export async function GET() {
+export async function GET(req: NextRequest) {
   const session = await auth();
   if (!session?.user?.id) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
+  const { searchParams } = new URL(req.url);
+  const org = validateOrg(searchParams.get("org"));
+
   try {
-    const preferences = await getUserPreferences(session.user.id);
+    const preferences = await getUserPreferences(session.user.id, org);
     return NextResponse.json(preferences);
   } catch (error) {
     console.error("Preferences GET error:", error);
@@ -31,10 +35,17 @@ export async function PUT(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
+  const { searchParams } = new URL(req.url);
+  const org = validateOrg(searchParams.get("org"));
+
   try {
     const body = await req.json();
     const parsed = PreferencesSchema.parse(body);
-    const preferences = await updateUserPreferences(session.user.id, parsed);
+    const preferences = await updateUserPreferences(
+      session.user.id,
+      parsed,
+      org
+    );
     return NextResponse.json(preferences);
   } catch (error) {
     console.error("Preferences PUT error:", error);

--- a/src/components/providers/assistant-provider.tsx
+++ b/src/components/providers/assistant-provider.tsx
@@ -30,8 +30,14 @@ export function useChatContext() {
   return ctx;
 }
 
-export function AssistantProvider({ children }: { children: ReactNode }) {
-  const { org, setOrg } = useOrg();
+export function AssistantProvider({
+  children,
+  defaultOrg,
+}: {
+  children: ReactNode;
+  defaultOrg: string;
+}) {
+  const { org, setOrg } = useOrg(defaultOrg);
   const {
     runtime,
     sendMessage,

--- a/src/components/providers/assistant-provider.tsx
+++ b/src/components/providers/assistant-provider.tsx
@@ -2,6 +2,7 @@
 
 import { AssistantRuntimeProvider } from "@assistant-ui/react";
 import { useChatRuntime } from "@/hooks/use-chat-runtime";
+import { useOrg } from "@/hooks/use-org";
 import { createContext, useContext, ReactNode } from "react";
 
 interface ChatContextValue {
@@ -16,6 +17,8 @@ interface ChatContextValue {
   streamingText: string;
   finalizeComplete: () => void;
   isCompleting: boolean;
+  org: string;
+  setOrg: (org: string) => void;
 }
 
 const ChatContext = createContext<ChatContextValue | null>(null);
@@ -28,6 +31,7 @@ export function useChatContext() {
 }
 
 export function AssistantProvider({ children }: { children: ReactNode }) {
+  const { org, setOrg } = useOrg();
   const {
     runtime,
     sendMessage,
@@ -37,7 +41,7 @@ export function AssistantProvider({ children }: { children: ReactNode }) {
     streamingText,
     finalizeComplete,
     isCompleting,
-  } = useChatRuntime();
+  } = useChatRuntime(org);
 
   return (
     <ChatContext.Provider
@@ -49,6 +53,8 @@ export function AssistantProvider({ children }: { children: ReactNode }) {
         streamingText,
         finalizeComplete,
         isCompleting,
+        org,
+        setOrg,
       }}
     >
       <AssistantRuntimeProvider runtime={runtime}>

--- a/src/components/user-menu.tsx
+++ b/src/components/user-menu.tsx
@@ -1,14 +1,16 @@
 "use client";
 
-import { LogOutIcon } from "lucide-react";
+import { LogOutIcon, BuildingIcon } from "lucide-react";
 import { getCsrfToken } from "next-auth/react";
 import { useEffect, useState } from "react";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { useChatContext } from "@/components/providers/assistant-provider";
 
 interface UserMenuProps {
   userInitial: string;
@@ -16,10 +18,24 @@ interface UserMenuProps {
 
 export function UserMenu({ userInitial }: UserMenuProps) {
   const [csrfToken, setCsrfToken] = useState<string>("");
+  const { org, setOrg } = useChatContext();
+  const [orgDraft, setOrgDraft] = useState(org);
 
   useEffect(() => {
     getCsrfToken().then((token) => setCsrfToken(token || ""));
   }, []);
+
+  // Keep draft in sync when org changes externally
+  useEffect(() => {
+    setOrgDraft(org);
+  }, [org]);
+
+  const commitOrg = () => {
+    const trimmed = orgDraft.trim();
+    if (trimmed && trimmed !== org) {
+      setOrg(trimmed);
+    }
+  };
 
   return (
     <DropdownMenu>
@@ -35,6 +51,26 @@ export function UserMenu({ userInitial }: UserMenuProps) {
         align="end"
         className="w-56 border-[#00000015] bg-white shadow-lg dark:border-[#6c6a6040] dark:bg-[#1f1e1b]"
       >
+        <div className="px-2 py-2">
+          <label className="flex items-center gap-2 text-xs font-medium text-[#6b6a68] dark:text-[#9a9893]">
+            <BuildingIcon className="h-3.5 w-3.5" />
+            Organization
+          </label>
+          <input
+            type="text"
+            value={orgDraft}
+            onChange={(e) => setOrgDraft(e.target.value)}
+            onBlur={commitOrg}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                commitOrg();
+                e.currentTarget.blur();
+              }
+            }}
+            className="mt-1 w-full rounded-md border border-[#00000015] bg-[#f5f5f0] px-2 py-1.5 text-sm text-[#1a1a18] outline-none focus:border-[#ae5630] focus:ring-1 focus:ring-[#ae5630] dark:border-[#6c6a6040] dark:bg-[#393937] dark:text-[#eee]"
+          />
+        </div>
+        <DropdownMenuSeparator className="bg-[#00000010] dark:bg-[#6c6a6030]" />
         <form action="/api/auth/signout" method="POST">
           <input type="hidden" name="csrfToken" value={csrfToken} />
           <input type="hidden" name="callbackUrl" value="/login" />

--- a/src/components/user-menu.tsx
+++ b/src/components/user-menu.tsx
@@ -11,6 +11,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useChatContext } from "@/components/providers/assistant-provider";
+import { isValidOrg } from "@/lib/validate-org";
 
 interface UserMenuProps {
   userInitial: string;
@@ -30,9 +31,11 @@ export function UserMenu({ userInitial }: UserMenuProps) {
     setOrgDraft(org);
   }, [org]);
 
+  const draftValid = isValidOrg(orgDraft.trim());
+
   const commitOrg = () => {
     const trimmed = orgDraft.trim();
-    if (trimmed && trimmed !== org) {
+    if (trimmed && trimmed !== org && draftValid) {
       setOrg(trimmed);
     }
   };
@@ -67,8 +70,17 @@ export function UserMenu({ userInitial }: UserMenuProps) {
                 e.currentTarget.blur();
               }
             }}
-            className="mt-1 w-full rounded-md border border-[#00000015] bg-[#f5f5f0] px-2 py-1.5 text-sm text-[#1a1a18] outline-none focus:border-[#ae5630] focus:ring-1 focus:ring-[#ae5630] dark:border-[#6c6a6040] dark:bg-[#393937] dark:text-[#eee]"
+            className={`mt-1 w-full rounded-md border px-2 py-1.5 text-sm outline-none ${
+              !draftValid
+                ? "border-red-400 text-red-700 dark:border-red-500 dark:text-red-400"
+                : "border-[#00000015] text-[#1a1a18] focus:border-[#ae5630] focus:ring-1 focus:ring-[#ae5630] dark:border-[#6c6a6040] dark:text-[#eee]"
+            } bg-[#f5f5f0] dark:bg-[#393937]`}
           />
+          {!draftValid && (
+            <p className="mt-1 text-xs text-red-500">
+              Letters, numbers, hyphens, and underscores only
+            </p>
+          )}
         </div>
         <DropdownMenuSeparator className="bg-[#00000010] dark:bg-[#6c6a6030]" />
         <form action="/api/auth/signout" method="POST">

--- a/src/hooks/use-chat-runtime.ts
+++ b/src/hooks/use-chat-runtime.ts
@@ -73,7 +73,6 @@ export function useChatRuntime(org: string) {
   const [streamingText, setStreamingText] = useState<string>("");
   const [isAudioRequest, setIsAudioRequest] = useState(false);
   const isAudioRequestRef = useRef(false);
-  const historyLoadedRef = useRef(false);
   const pendingCompleteRef = useRef<{ message: ChatMessage } | null>(null);
   const [isCompleting, setIsCompleting] = useState(false);
   const streamingTextRef = useRef(streamingText);
@@ -90,51 +89,60 @@ export function useChatRuntime(org: string) {
   }, []);
 
   // Load chat history and convert to ChatMessage format
-  const loadHistory = useCallback(async (): Promise<ChatMessage[]> => {
-    try {
-      const response = await fetch(
-        `/api/chat/history?org=${encodeURIComponent(org)}`
-      );
-      if (!response.ok) {
+  const loadHistory = useCallback(
+    async (signal?: AbortSignal): Promise<ChatMessage[]> => {
+      try {
+        const response = await fetch(
+          `/api/chat/history?org=${encodeURIComponent(org)}`,
+          { signal }
+        );
+        if (!response.ok) {
+          return [];
+        }
+
+        const history: ChatHistoryResponse = await response.json();
+
+        // Convert history entries to ChatMessage format
+        const historyMessages: ChatMessage[] = [];
+
+        history.entries.forEach((entry, i) => {
+          // Add user message
+          historyMessages.push({
+            id: `history-user-${i}`,
+            role: "user",
+            content: [{ type: "text" as const, text: entry.user_message }],
+            createdAt: entry.created_at
+              ? new Date(entry.created_at)
+              : new Date(),
+          });
+
+          // Add assistant message
+          historyMessages.push({
+            id: `history-assistant-${i}`,
+            role: "assistant",
+            content: [
+              { type: "text" as const, text: entry.assistant_response },
+            ],
+            createdAt: entry.created_at
+              ? new Date(entry.created_at)
+              : new Date(),
+            audioUrl: entry.voice_audio_url
+              ? `/api/audio?url=${encodeURIComponent(entry.voice_audio_url)}`
+              : undefined,
+          });
+        });
+
+        return historyMessages;
+      } catch {
         return [];
       }
-
-      const history: ChatHistoryResponse = await response.json();
-
-      // Convert history entries to ChatMessage format
-      const historyMessages: ChatMessage[] = [];
-
-      history.entries.forEach((entry, i) => {
-        // Add user message
-        historyMessages.push({
-          id: `history-user-${i}`,
-          role: "user",
-          content: [{ type: "text" as const, text: entry.user_message }],
-          createdAt: entry.created_at ? new Date(entry.created_at) : new Date(),
-        });
-
-        // Add assistant message
-        historyMessages.push({
-          id: `history-assistant-${i}`,
-          role: "assistant",
-          content: [{ type: "text" as const, text: entry.assistant_response }],
-          createdAt: entry.created_at ? new Date(entry.created_at) : new Date(),
-          audioUrl: entry.voice_audio_url
-            ? `/api/audio?url=${encodeURIComponent(entry.voice_audio_url)}`
-            : undefined,
-        });
-      });
-
-      return historyMessages;
-    } catch {
-      return [];
-    }
-  }, [org]);
+    },
+    [org]
+  );
 
   // Load history on mount and when org changes
   useEffect(() => {
     // On org change, reset state and reload
-    historyLoadedRef.current = true;
     abortControllerRef.current?.abort();
     setMessages([]);
     setStreamingText("");
@@ -142,11 +150,17 @@ export function useChatRuntime(org: string) {
     setStatusMessage(null);
     pendingCompleteRef.current = null;
 
-    loadHistory().then((historyMessages) => {
+    const historyAbort = new AbortController();
+
+    loadHistory(historyAbort.signal).then((historyMessages) => {
       if (historyMessages.length > 0) {
         setMessages(historyMessages);
       }
     });
+
+    return () => {
+      historyAbort.abort();
+    };
   }, [loadHistory]);
 
   // Finalize a pending completion — called by AnimatedText when animation catches up

--- a/src/hooks/use-chat-runtime.ts
+++ b/src/hooks/use-chat-runtime.ts
@@ -66,7 +66,7 @@ function createMessage(
   };
 }
 
-export function useChatRuntime() {
+export function useChatRuntime(org: string) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
@@ -92,7 +92,9 @@ export function useChatRuntime() {
   // Load chat history and convert to ChatMessage format
   const loadHistory = useCallback(async (): Promise<ChatMessage[]> => {
     try {
-      const response = await fetch("/api/chat/history");
+      const response = await fetch(
+        `/api/chat/history?org=${encodeURIComponent(org)}`
+      );
       if (!response.ok) {
         return [];
       }
@@ -127,18 +129,24 @@ export function useChatRuntime() {
     } catch {
       return [];
     }
-  }, []);
+  }, [org]);
 
-  // Load history on mount
+  // Load history on mount and when org changes
   useEffect(() => {
-    if (!historyLoadedRef.current) {
-      historyLoadedRef.current = true;
-      loadHistory().then((historyMessages) => {
-        if (historyMessages.length > 0) {
-          setMessages(historyMessages);
-        }
-      });
-    }
+    // On org change, reset state and reload
+    historyLoadedRef.current = true;
+    abortControllerRef.current?.abort();
+    setMessages([]);
+    setStreamingText("");
+    setIsLoading(false);
+    setStatusMessage(null);
+    pendingCompleteRef.current = null;
+
+    loadHistory().then((historyMessages) => {
+      if (historyMessages.length > 0) {
+        setMessages(historyMessages);
+      }
+    });
   }, [loadHistory]);
 
   // Finalize a pending completion — called by AnimatedText when animation catches up
@@ -271,6 +279,7 @@ export function useChatRuntime() {
             message_type: audioBase64 ? "audio" : "text",
             audio_base64: audioBase64,
             audio_format: audioFormat,
+            org,
           }),
           signal: abortController.signal,
         });
@@ -402,7 +411,7 @@ export function useChatRuntime() {
         abortControllerRef.current = null;
       }
     },
-    [handleComplete, handleError]
+    [handleComplete, handleError, org]
   );
 
   // Combine messages with streaming message if present.

--- a/src/hooks/use-org.ts
+++ b/src/hooks/use-org.ts
@@ -1,29 +1,25 @@
 "use client";
 
 import { useSyncExternalStore, useCallback } from "react";
+import { isValidOrg } from "@/lib/validate-org";
 
 const STORAGE_KEY = "bt-org";
-const DEFAULT_ORG = "unfoldingWord";
 
 function subscribe(callback: () => void) {
   window.addEventListener("storage", callback);
   return () => window.removeEventListener("storage", callback);
 }
 
-function getSnapshot() {
-  return localStorage.getItem(STORAGE_KEY) || DEFAULT_ORG;
-}
-
-function getServerSnapshot() {
-  return DEFAULT_ORG;
-}
-
-export function useOrg() {
-  const org = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+export function useOrg(defaultOrg: string) {
+  const org = useSyncExternalStore(
+    subscribe,
+    () => localStorage.getItem(STORAGE_KEY) || defaultOrg,
+    () => defaultOrg
+  );
 
   const setOrg = useCallback((value: string) => {
     const trimmed = value.trim();
-    if (trimmed) {
+    if (trimmed && isValidOrg(trimmed)) {
       localStorage.setItem(STORAGE_KEY, trimmed);
       window.dispatchEvent(new StorageEvent("storage", { key: STORAGE_KEY }));
     }

--- a/src/hooks/use-org.ts
+++ b/src/hooks/use-org.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { useSyncExternalStore, useCallback } from "react";
+
+const STORAGE_KEY = "bt-org";
+const DEFAULT_ORG = "unfoldingWord";
+
+function subscribe(callback: () => void) {
+  window.addEventListener("storage", callback);
+  return () => window.removeEventListener("storage", callback);
+}
+
+function getSnapshot() {
+  return localStorage.getItem(STORAGE_KEY) || DEFAULT_ORG;
+}
+
+function getServerSnapshot() {
+  return DEFAULT_ORG;
+}
+
+export function useOrg() {
+  const org = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+  const setOrg = useCallback((value: string) => {
+    const trimmed = value.trim();
+    if (trimmed) {
+      localStorage.setItem(STORAGE_KEY, trimmed);
+      window.dispatchEvent(new StorageEvent("storage", { key: STORAGE_KEY }));
+    }
+  }, []);
+
+  return { org, setOrg };
+}

--- a/src/lib/engine-client.ts
+++ b/src/lib/engine-client.ts
@@ -12,10 +12,11 @@ function getAuthHeaders(): HeadersInit {
 }
 
 export async function getUserPreferences(
-  userId: string
+  userId: string,
+  org: string = DEFAULT_ORG
 ): Promise<UserPreferences> {
   const response = await fetch(
-    `${ENGINE_BASE_URL}/api/v1/orgs/${DEFAULT_ORG}/users/${userId}/preferences`,
+    `${ENGINE_BASE_URL}/api/v1/orgs/${org}/users/${userId}/preferences`,
     { headers: getAuthHeaders() }
   );
 
@@ -32,10 +33,11 @@ export async function getUserPreferences(
 
 export async function updateUserPreferences(
   userId: string,
-  preferences: Partial<UserPreferences>
+  preferences: Partial<UserPreferences>,
+  org: string = DEFAULT_ORG
 ): Promise<UserPreferences> {
   const response = await fetch(
-    `${ENGINE_BASE_URL}/api/v1/orgs/${DEFAULT_ORG}/users/${userId}/preferences`,
+    `${ENGINE_BASE_URL}/api/v1/orgs/${org}/users/${userId}/preferences`,
     {
       method: "PUT",
       headers: getAuthHeaders(),
@@ -53,7 +55,8 @@ export async function updateUserPreferences(
 export async function getChatHistory(
   userId: string,
   limit = 50,
-  offset = 0
+  offset = 0,
+  org: string = DEFAULT_ORG
 ): Promise<ChatHistoryResponse> {
   const params = new URLSearchParams({
     limit: String(limit),
@@ -61,7 +64,7 @@ export async function getChatHistory(
   });
 
   const response = await fetch(
-    `${ENGINE_BASE_URL}/api/v1/orgs/${DEFAULT_ORG}/users/${userId}/history?${params}`,
+    `${ENGINE_BASE_URL}/api/v1/orgs/${org}/users/${userId}/history?${params}`,
     { headers: getAuthHeaders() }
   );
 

--- a/src/lib/validate-org.ts
+++ b/src/lib/validate-org.ts
@@ -1,0 +1,9 @@
+const DEFAULT_ORG = process.env.DEFAULT_ORG || "unfoldingWord";
+const ORG_PATTERN = /^[a-zA-Z0-9_-]{1,100}$/;
+
+export function validateOrg(value: string | null | undefined): string {
+  if (value && ORG_PATTERN.test(value)) {
+    return value;
+  }
+  return DEFAULT_ORG;
+}

--- a/src/lib/validate-org.ts
+++ b/src/lib/validate-org.ts
@@ -1,5 +1,10 @@
 const DEFAULT_ORG = process.env.DEFAULT_ORG || "unfoldingWord";
-const ORG_PATTERN = /^[a-zA-Z0-9_-]{1,100}$/;
+
+export const ORG_PATTERN = /^[a-zA-Z0-9_-]{1,100}$/;
+
+export function isValidOrg(value: string): boolean {
+  return ORG_PATTERN.test(value);
+}
 
 export function validateOrg(value: string | null | undefined): string {
   if (value && ORG_PATTERN.test(value)) {


### PR DESCRIPTION
## Summary
- Adds an org text input to the user menu dropdown so users can switch between organizations instead of always hitting `unfoldingWord`
- Chosen org persists in `localStorage` and is threaded through all API routes (`/chat/stream`, `/chat/history`, `/preferences`) to the engine
- Server-side regex validation (`/^[a-zA-Z0-9_-]{1,100}$/`) prevents path traversal since org is interpolated into URL paths
- Changing org clears chat messages and reloads history for the new org

## Test plan
- [ ] Click avatar in top-right — org input appears above "Sign out", defaulting to "unfoldingWord"
- [ ] Change org value, press Enter or blur — chat clears and history reloads for the new org
- [ ] Refresh the page — chosen org persists (check localStorage key `bt-org`)
- [ ] Send a message — verify `/api/chat/stream` request body contains the chosen org (Network tab)
- [ ] Verify build passes with no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)