### PR TITLE
fix(ci): set NEXT_PUBLIC_ENABLE_ORG_SWITCHER at build time on staging

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -57,6 +57,8 @@ jobs:
 
       - name: Build for Cloudflare
         run: npx opennextjs-cloudflare build
+        env:
+          NEXT_PUBLIC_ENABLE_ORG_SWITCHER: "true"
 
       - name: Deploy to Staging
         run: npx opennextjs-cloudflare deploy --env staging


### PR DESCRIPTION
## Summary

- Next.js inlines `NEXT_PUBLIC_*` at **build time**, but the staging workflow was only setting the flag via `wrangler.jsonc` `env.staging.vars` — a Worker runtime var, which lands *after* the client bundle has already been compiled. Result: staging built with `ORG_SWITCHER_ENABLED === false`, so the switcher was hidden on staging too.
- Sets `NEXT_PUBLIC_ENABLE_ORG_SWITCHER=true` on the `Build for Cloudflare` step in `deploy-staging.yml`. Keep the wrangler entry so SSR at runtime matches the client bundle (no hydration mismatch). Prod workflow is unchanged, so prod correctly keeps the switcher hidden.

## Test plan

- [x] `npm run typecheck` / `npm run build` locally.
- [ ] Merge → Deploy Staging auto-runs → switcher visible on staging.
- [ ] Prod (next manual dispatch, not part of this PR) continues to hide the switcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)