### PR TITLE
fix: inline-video rendering for FIA plain text video links (v1.7.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bt-servant-web-client",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/components/assistant-ui/markdown-text.tsx
+++ b/src/components/assistant-ui/markdown-text.tsx
@@ -9,33 +9,17 @@ import {
   useIsMarkdownCodeBlock,
 } from "@assistant-ui/react-markdown";
 import remarkGfm from "remark-gfm";
-import {
-  Children,
-  isValidElement,
-  type FC,
-  type ReactNode,
-  memo,
-  useState,
-} from "react";
+import { type FC, memo, useState } from "react";
 import { CheckIcon, CopyIcon } from "lucide-react";
 
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
+import { remarkDedupeVideoLinks } from "@/lib/remark-dedupe-video-links";
 import { cn } from "@/lib/utils";
-
-const VIDEO_HREF_RE = /\.(mp4|webm|ogv|mov|m4v)(\?|#|$)/i;
-
-function hasImageChild(children: ReactNode): boolean {
-  return Children.toArray(children).some(
-    (c) =>
-      isValidElement(c) &&
-      typeof (c.props as { src?: unknown })?.src === "string"
-  );
-}
 
 const MarkdownTextImpl = () => {
   return (
     <MarkdownTextPrimitive
-      remarkPlugins={[remarkGfm]}
+      remarkPlugins={[remarkGfm, remarkDedupeVideoLinks]}
       className="prose prose-neutral dark:prose-invert max-w-none"
       components={defaultComponents}
     />
@@ -116,7 +100,9 @@ const defaultComponents = memoizeMarkdownComponents({
     />
   ),
   a: ({ className, href, children, ...props }) => {
-    if (href && VIDEO_HREF_RE.test(href) && hasImageChild(children)) {
+    const isVideoFirst =
+      (props as { "data-video-first"?: string })["data-video-first"] === "true";
+    if (href && isVideoFirst) {
       return (
         <video
           src={href}

--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -24,29 +24,11 @@ import {
   faCircleInfo,
   faArrowDown,
 } from "@fortawesome/pro-regular-svg-icons";
-import {
-  Children,
-  isValidElement,
-  useState,
-  useEffect,
-  useRef,
-  useCallback,
-  type FC,
-  type ReactNode,
-} from "react";
+import { useState, useEffect, useRef, useCallback, type FC } from "react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { remarkDedupeVideoLinks } from "@/lib/remark-dedupe-video-links";
 import { cn } from "@/lib/utils";
-
-const VIDEO_HREF_RE = /\.(mp4|webm|ogv|mov|m4v)(\?|#|$)/i;
-
-function hasImageChild(children: ReactNode): boolean {
-  return Children.toArray(children).some(
-    (c) =>
-      isValidElement(c) &&
-      typeof (c.props as { src?: unknown })?.src === "string"
-  );
-}
 
 // Animation constants
 const CHARS_PER_TICK = 2;
@@ -90,7 +72,8 @@ const streamingMarkdownComponents = {
     />
   ),
   a: ({ node: _n, className, href, children, ...props }: any) => {
-    if (href && VIDEO_HREF_RE.test(href) && hasImageChild(children)) {
+    const isVideoFirst = props["data-video-first"] === "true";
+    if (href && isVideoFirst) {
       return (
         <video
           src={href}
@@ -522,7 +505,7 @@ const AnimatedText: FC<{
 
   return (
     <Markdown
-      remarkPlugins={[remarkGfm]}
+      remarkPlugins={[remarkGfm, remarkDedupeVideoLinks]}
       components={streamingMarkdownComponents}
     >
       {displayedText}

--- a/src/lib/remark-dedupe-video-links.ts
+++ b/src/lib/remark-dedupe-video-links.ts
@@ -1,0 +1,24 @@
+import type { Root } from "mdast";
+import { visit } from "unist-util-visit";
+
+const VIDEO_URL_RE = /\.(mp4|webm|ogv|mov|m4v)(\?|#|$)/i;
+
+// Tag the first link to each video URL with data-video-first so the renderer
+// can upgrade it to an inline <video>. Later links to the same URL stay as
+// anchors — prevents stacked players when the worker emits a linked thumbnail
+// and a redundant "Watch the Video" text link to the same .mp4.
+export function remarkDedupeVideoLinks() {
+  return (tree: Root) => {
+    const seen = new Set<string>();
+    visit(tree, "link", (node) => {
+      if (!VIDEO_URL_RE.test(node.url)) return;
+      if (seen.has(node.url)) return;
+      seen.add(node.url);
+      const data = (node.data ??= {});
+      const hProps = ((
+        data as { hProperties?: Record<string, unknown> }
+      ).hProperties ??= {});
+      hProps["data-video-first"] = "true";
+    });
+  };
+}


### PR DESCRIPTION
## Summary

v1.7.0 only embedded `<video>` when the markdown link wrapped an image (`[![thumb](jpg)](mp4)`) — fine for Aquifer VideoBibleDictionary, but FIA `fia_get_pericope_media` responses ship plain bullet-list text links (`- [Wilderness Video](mp4)`) that were left as plain anchors.

Replace the heuristic with a small remark plugin that walks the mdast once, tracks seen video URLs, and tags the first occurrence with `data-video-first="true"`. The `<a>` handler now embeds a `<video>` only when that flag is present; later links to the same URL fall through to the standard new-tab anchor. Keeps the anti-double-player behavior for Aquifer while giving FIA bullet lists one inline player per video.

Version bumped to 1.7.1.

## Context

Verified against real worker output via cf-logs. Two shapes in the wild:

- Aquifer (Gethsemane, Garden Tomb): `[![thumb](jpg)](mp4)` + redundant `[Watch the Video (108 s)](mp4)` to the same url.
- FIA (Matthew 4/14/28): plain bullets, each a unique mp4.

Locally rendered both shapes through `react-markdown + remark-gfm + remarkDedupeVideoLinks` and confirmed:

- Aquifer: exactly one `<video>` + one new-tab `<a>`.
- FIA: one `<video>` per bullet.
- Non-video links: new-tab anchor.
- Same URL emitted 3x: only the first becomes `<video>`, rest stay as anchors.

## Test plan

- [ ] FIA Matthew prompt (videos across pericopes) — each bullet renders an inline `<video>`.
- [ ] Aquifer VideoBibleDictionary prompt (e.g. Gethsemane) — one inline `<video>` above a new-tab "Watch the Video" link.
- [ ] Ordinary links continue to open in a new tab.
- [ ] Plain `![]()` images still render as `<img>`.
- [ ] Stream each message mid-generation — no jank at streaming→final swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)