### PR TITLE
feat: render PDF attachments in assistant messages (#34)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bt-servant-web-client",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bt-servant-web-client",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "dependencies": {
         "@assistant-ui/react": "^0.11.53",
         "@assistant-ui/react-markdown": "^0.11.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bt-servant-web-client",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/components/assistant-ui/attachment-chips.tsx
+++ b/src/components/assistant-ui/attachment-chips.tsx
@@ -13,23 +13,30 @@ export const AttachmentChips: FC<AttachmentChipsProps> = ({ attachments }) => {
   return (
     <div className="mt-3 flex flex-wrap gap-2">
       {attachments.map((a) => {
-        if (a.type !== "pdf") return null;
-        return (
-          <a
-            key={a.url}
-            href={a.url}
-            download={a.filename}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-2 rounded-md border border-[#d8d6d0] bg-white px-3 py-1.5 font-sans text-[0.8rem] text-[#1a1a18] transition-colors hover:bg-[#f5f3ee] dark:border-[#3a3937] dark:bg-[#1a1a18] dark:text-[#eee] dark:hover:bg-[#2a2927]"
-          >
-            <FileText size={14} className="shrink-0" />
-            <span className="max-w-[18rem] truncate">{a.filename}</span>
-            <span className="text-[#8a8985] dark:text-[#9a9893]">
-              · {formatBytes(a.size_bytes)}
-            </span>
-          </a>
-        );
+        // Switch-by-discriminant: when a non-pdf variant is added to the
+        // Attachment union, add a case here. Until then, `default` is
+        // unreachable and a `never` exhaustiveness assignment would error.
+        switch (a.type) {
+          case "pdf":
+            return (
+              <a
+                key={a.url}
+                href={a.url}
+                download={a.filename}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 rounded-md border border-[#d8d6d0] bg-white px-3 py-1.5 font-sans text-[0.8rem] text-[#1a1a18] transition-colors hover:bg-[#f5f3ee] dark:border-[#3a3937] dark:bg-[#1a1a18] dark:text-[#eee] dark:hover:bg-[#2a2927]"
+              >
+                <FileText size={14} className="shrink-0" />
+                <span className="max-w-[18rem] truncate">{a.filename}</span>
+                <span className="text-[#8a8985] dark:text-[#9a9893]">
+                  · {formatBytes(a.size_bytes)}
+                </span>
+              </a>
+            );
+          default:
+            return null;
+        }
       })}
     </div>
   );

--- a/src/components/assistant-ui/attachment-chips.tsx
+++ b/src/components/assistant-ui/attachment-chips.tsx
@@ -1,0 +1,36 @@
+import { FileText } from "lucide-react";
+import type { FC } from "react";
+import type { Attachment } from "@/types/engine";
+import { formatBytes } from "@/lib/utils";
+
+interface AttachmentChipsProps {
+  attachments: Attachment[];
+}
+
+export const AttachmentChips: FC<AttachmentChipsProps> = ({ attachments }) => {
+  if (!attachments.length) return null;
+
+  return (
+    <div className="mt-3 flex flex-wrap gap-2">
+      {attachments.map((a) => {
+        if (a.type !== "pdf") return null;
+        return (
+          <a
+            key={a.url}
+            href={a.url}
+            download={a.filename}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-md border border-[#d8d6d0] bg-white px-3 py-1.5 font-sans text-[0.8rem] text-[#1a1a18] transition-colors hover:bg-[#f5f3ee] dark:border-[#3a3937] dark:bg-[#1a1a18] dark:text-[#eee] dark:hover:bg-[#2a2927]"
+          >
+            <FileText size={14} className="shrink-0" />
+            <span className="max-w-[18rem] truncate">{a.filename}</span>
+            <span className="text-[#8a8985] dark:text-[#9a9893]">
+              · {formatBytes(a.size_bytes)}
+            </span>
+          </a>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -604,6 +604,8 @@ const AssistantMessage: FC = () => {
             </ActionBarPrimitive.Root>
           </div>
         </>
+      ) : hasAttachments ? (
+        <AttachmentChips attachments={attachments!} />
       ) : isLast && !isLoading ? (
         <div className="prose prose-neutral dark:prose-invert max-w-none font-serif leading-[1.65rem] text-[#1a1a18] dark:text-[#eee]">
           <p className="text-[#8a8985] italic dark:text-[#b8b5a9]">

--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { MarkdownText } from "@/components/assistant-ui/markdown-text";
+import { AttachmentChips } from "@/components/assistant-ui/attachment-chips";
 import { useChatContext } from "@/components/providers/assistant-provider";
 import { VoiceRecorder } from "@/components/voice/voice-recorder";
 import { AudioPlayer } from "@/components/voice/audio-player";
@@ -29,6 +30,7 @@ import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { remarkDedupeVideoLinks } from "@/lib/remark-dedupe-video-links";
 import { cn } from "@/lib/utils";
+import type { Attachment } from "@/types/engine";
 
 // Animation constants
 const CHARS_PER_TICK = 2;
@@ -525,6 +527,10 @@ const AssistantMessage: FC = () => {
     ({ message }) =>
       (message.metadata?.custom?.isStreaming as boolean | undefined) ?? false
   );
+  const attachments = useAssistantState(
+    ({ message }) =>
+      message.metadata?.custom?.attachments as Attachment[] | undefined
+  );
   const messageText = useAssistantState(({ message }) => {
     const firstPart = message.content[0];
     return firstPart?.type === "text" ? firstPart.text : "";
@@ -539,6 +545,7 @@ const AssistantMessage: FC = () => {
 
   const hasAudio = !isStreaming && (!!audioBase64 || !!audioUrl);
   const hasText = !!messageText;
+  const hasAttachments = !isStreaming && !!attachments?.length;
 
   return (
     <div className="relative mb-8 pl-2">
@@ -560,6 +567,7 @@ const AssistantMessage: FC = () => {
               )}
             </div>
           )}
+          {hasAttachments && <AttachmentChips attachments={attachments!} />}
         </div>
       ) : isStreaming ? (
         <div className="prose prose-neutral dark:prose-invert max-w-none font-serif leading-[1.65rem] text-[#1a1a18] dark:text-[#eee]">
@@ -574,6 +582,8 @@ const AssistantMessage: FC = () => {
           <div className="prose prose-neutral dark:prose-invert max-w-none font-serif leading-[1.65rem] text-[#1a1a18] dark:text-[#eee]">
             <MessagePrimitive.Parts components={{ Text: MarkdownText }} />
           </div>
+
+          {hasAttachments && <AttachmentChips attachments={attachments!} />}
 
           <div className="pointer-events-none absolute inset-x-0 bottom-0">
             <ActionBarPrimitive.Root

--- a/src/hooks/use-chat-runtime.ts
+++ b/src/hooks/use-chat-runtime.ts
@@ -6,6 +6,7 @@ import {
 } from "@assistant-ui/react";
 import { useState, useCallback, useRef, useMemo, useEffect } from "react";
 import type {
+  Attachment,
   ChatResponse,
   ChatHistoryResponse,
   SSEEvent,
@@ -19,6 +20,7 @@ interface ChatMessage {
   audioBase64?: string;
   audioUrl?: string;
   isStreaming?: boolean;
+  attachments?: Attachment[];
 }
 
 function toThreadMessage(message: ChatMessage): ThreadMessageLike {
@@ -32,6 +34,7 @@ function toThreadMessage(message: ChatMessage): ThreadMessageLike {
         audioBase64: message.audioBase64,
         audioUrl: message.audioUrl,
         isStreaming: message.isStreaming,
+        attachments: message.attachments,
       },
     },
   };
@@ -53,7 +56,12 @@ function createMessage(
   id: string,
   role: "user" | "assistant",
   content: string,
-  opts?: { audioBase64?: string; audioUrl?: string; isStreaming?: boolean }
+  opts?: {
+    audioBase64?: string;
+    audioUrl?: string;
+    isStreaming?: boolean;
+    attachments?: Attachment[];
+  }
 ): ChatMessage {
   return {
     id,
@@ -63,6 +71,7 @@ function createMessage(
     audioBase64: opts?.audioBase64,
     audioUrl: opts?.audioUrl,
     isStreaming: opts?.isStreaming,
+    attachments: opts?.attachments,
   };
 }
 
@@ -128,6 +137,9 @@ export function useChatRuntime(org: string) {
               : new Date(),
             audioUrl: entry.voice_audio_url
               ? `/api/audio?url=${encodeURIComponent(entry.voice_audio_url)}`
+              : undefined,
+            attachments: entry.attachments?.length
+              ? entry.attachments
               : undefined,
           });
         });
@@ -197,6 +209,7 @@ export function useChatRuntime(org: string) {
       {
         audioBase64: data.voice_audio_base64 || undefined,
         audioUrl,
+        attachments: data.attachments?.length ? data.attachments : undefined,
       }
     );
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,16 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let i = 0;
+  let value = bytes;
+  while (value >= 1024 && i < units.length - 1) {
+    value /= 1024;
+    i++;
+  }
+  const rounded = i === 0 ? value : Math.round(value * 10) / 10;
+  return `${rounded} ${units[i]}`;
+}

--- a/src/types/engine.ts
+++ b/src/types/engine.ts
@@ -12,13 +12,17 @@ export interface ChatRequest {
   org?: string; // Organization for MCP server selection (defaults to DEFAULT_ORG)
 }
 
-export type Attachment = {
+export type PdfAttachment = {
   type: "pdf";
   url: string;
   filename: string;
   size_bytes: number;
   mime_type: "application/pdf";
 };
+
+// Discriminated by `type`. Adding a new variant (e.g. AudioAttachment) here
+// forces consumers that switch on `type` to handle it via exhaustiveness checks.
+export type Attachment = PdfAttachment;
 
 export interface ChatResponse {
   responses: string[];

--- a/src/types/engine.ts
+++ b/src/types/engine.ts
@@ -12,11 +12,20 @@ export interface ChatRequest {
   org?: string; // Organization for MCP server selection (defaults to DEFAULT_ORG)
 }
 
+export type Attachment = {
+  type: "pdf";
+  url: string;
+  filename: string;
+  size_bytes: number;
+  mime_type: "application/pdf";
+};
+
 export interface ChatResponse {
   responses: string[];
   response_language: string;
   voice_audio_base64: string | null;
   voice_audio_url?: string;
+  attachments?: Attachment[];
 }
 
 export interface UserPreferences {
@@ -29,6 +38,7 @@ export interface ChatHistoryEntry {
   timestamp?: number;
   created_at?: string | null;
   voice_audio_url?: string | null;
+  attachments?: Attachment[] | null;
 }
 
 export interface ChatHistoryResponse {


### PR DESCRIPTION
## Summary
- Threads the worker's new `ChatResponse.attachments[]` field (added in bt-servant-worker v2.17.5 / PR #174) through the streaming runtime and history loader into a download chip rendered in the assistant message bubble.
- Models `Attachment` as a discriminated union (`type: 'pdf'` only in v1) so future audio/image variants are non-breaking.
- Chip renders independently of the transcript toggle when audio is also present — audio and PDFs are peer artifacts.

Closes #34.

## Test plan
- [ ] `npm run dev` against staging worker, log in, send "Generate a print-ready PDF of John from BSB."
- [ ] Cold-cache (~25–30s): assistant message renders text + PDF chip showing `bsb-JHN-bsb-empirical.pdf · ~351 KB`.
- [ ] Click chip opens PDF in a new tab; `download` attribute saves with the right filename; Network tab shows `200 application/pdf`.
- [ ] Repeat the request — worker hits cache (~8s), chip renders identically (same URL).
- [ ] Reload the page — confirms forward-compatible history shape (chip persists if worker returns `attachments` on history entries; otherwise text-only, no error).
- [ ] Combined case: PDF request with voice enabled — audio player and chip both visible, chip not hidden by transcript toggle.
- [ ] `npm run typecheck` and `npm run lint` pass (verified locally; pre-commit hook also runs build successfully).

🤖 Generated with [Claude Code](https://claude.com/claude-code)