### PR TITLE
fix(ci): regenerate Cloudflare env types before deploy build

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -49,6 +49,13 @@ jobs:
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
 
+      - name: Generate Cloudflare env types
+        # cloudflare-env.d.ts is gitignored; next build's typecheck depends
+        # on it for binding-typed access (CHAT_ORG_KV, etc.). Without this,
+        # the deploy fails with "Property 'CHAT_ORG_KV' does not exist on
+        # type 'CloudflareEnv'".
+        run: npm run cf-typegen
+
       - name: Build for Cloudflare
         run: npx opennextjs-cloudflare build
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -55,10 +55,15 @@ jobs:
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
 
+      - name: Generate Cloudflare env types
+        # cloudflare-env.d.ts is gitignored; next build's typecheck depends
+        # on it for binding-typed access (CHAT_ORG_KV, etc.). Without this,
+        # the deploy fails with "Property 'CHAT_ORG_KV' does not exist on
+        # type 'CloudflareEnv'".
+        run: npm run cf-typegen
+
       - name: Build for Cloudflare
         run: npx opennextjs-cloudflare build
-        env:
-          NEXT_PUBLIC_ENABLE_ORG_SWITCHER: "true"
 
       - name: Deploy to Staging
         run: npx opennextjs-cloudflare deploy --env staging


### PR DESCRIPTION
## Problem

PR #41 broke the deploy path. Both `deploy-staging.yml` and `deploy-cloudflare.yml` call `npx opennextjs-cloudflare build` which internally runs `next build`. `next build`'s typecheck sees `env.CHAT_ORG_KV.get(email)` in `src/lib/org-resolver.ts` and can't resolve the binding type because `cloudflare-env.d.ts` is gitignored and is never regenerated in the deploy workflows.

**Reproduced on staging post-merge:** [run 27474032551](https://github.com/unfoldingWord/bt-servant-web-client/actions/runs/27474032551) failed with:
```
./src/lib/org-resolver.ts:22:28
Type error: Property 'CHAT_ORG_KV' does not exist on type 'CloudflareEnv'.
```

## Fix

Add `npm run cf-typegen` as a step before `opennextjs-cloudflare build` in both deploy workflows. Mirrors the step PR #41 added to `.github/workflows/ci.yml`.

Also dropped the dangling `NEXT_PUBLIC_ENABLE_ORG_SWITCHER: \"true\"` env from the staging build step (the switcher itself was removed in PR #41; the env was left orphaned).

## What this PR does NOT fix

Even with this typecheck regression resolved, the deploy will still hit the pre-existing \`_global-error\` prerender failure tracked at #42 (\"Cannot read properties of null (reading 'useContext')\" on Next 16 + React 19). This PR restores honesty: deploys now fail at the actual upstream bug, not at a new typecheck regression PR #41 layered on top of it.

## Pattern caught (post-mortem)

The cloudflare-env.d.ts file is gitignored, so any workflow that exercises types needs to regenerate it first. PR #41 caught this in CI (rounds 1 and 2 of CI iteration) but missed the deploy workflows. Going forward, any new gitignored generated file that participates in typecheck should be regenerated in every workflow that runs \`tsc\`, \`next build\`, or similar.

## Test plan

- [ ] CI green on this PR
- [ ] Post-merge staging deploy gets past the typecheck step
- [ ] Post-merge staging deploy still fails at \`_global-error\` prerender (confirming #42 is the next gate)